### PR TITLE
Add new backends package to setup.py

### DIFF
--- a/celery_singleton/config.py
+++ b/celery_singleton/config.py
@@ -1,3 +1,5 @@
+import ast
+
 from importlib import import_module
 
 
@@ -24,7 +26,10 @@ class Config:
 
     @property
     def backend_kwargs(self):
-        return self.app.conf.get("singleton_backend_kwargs", {})
+        kwargs = self.app.conf.get("singleton_backend_kwargs", {})
+        if not isinstance(kwargs, dict):
+            kwargs = ast.literal_eval(kwargs)
+        return kwargs
 
     @property
     def backend_url(self):

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(
         'celery>=4.0.0',
         'redis>=2.10.5'
     ],
-    packages=['celery_singleton']
+    packages=['celery_singleton', 'celery_singleton.backends']
 )


### PR DESCRIPTION
When installing via `pip` the backends package isn't included in the resulting install.